### PR TITLE
Disable toolbar animation in viewWillAppear when SVWebViewController is ...

### DIFF
--- a/SVWebViewController/SVModalWebViewController.m
+++ b/SVWebViewController/SVModalWebViewController.m
@@ -40,7 +40,7 @@
 }
 
 - (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
+    [super viewWillAppear:NO];
     
     self.navigationBar.tintColor = self.toolbar.tintColor = self.barsTintColor;
 }


### PR DESCRIPTION
...contained in SVModalWebViewController

Fixes issue:

When presenting modally, there is a momentary flash of content from the underlying view behind where the toolbar will be.

(Noticed that this occurs in Shows.app too)

Notes:
- This implementation simply sends NO to [super viewWillAppear:]
- This may have unwanted effect on other animations. On iPad perhaps? 

You may want to fix the issue in a different way (or ignore it) but this was the quick fix I found and figured I'd share
