### PR TITLE
Add done button touch delegation to SVModalWebViewController 

### DIFF
--- a/SVWebViewController/SVModalWebViewController.h
+++ b/SVWebViewController/SVModalWebViewController.h
@@ -19,6 +19,14 @@ typedef NSUInteger SVWebViewControllerAvailableActions;
 
 
 @class SVWebViewController;
+@class SVModalWebViewController;
+
+@protocol SVModalWebViewControllerDelegate <NSObject>
+@optional
+
+- (void)modalWebViewControllerDoneButtonTouched:(SVModalWebViewController *)modalWebViewController;
+
+@end
 
 @interface SVModalWebViewController : UINavigationController
 
@@ -27,5 +35,6 @@ typedef NSUInteger SVWebViewControllerAvailableActions;
 
 @property (nonatomic, strong) UIColor *barsTintColor;
 @property (nonatomic, readwrite) SVWebViewControllerAvailableActions availableActions;
+@property (nonatomic, unsafe_unretained) id<SVModalWebViewControllerDelegate> modalWebViewControllerDelegate;
 
 @end

--- a/SVWebViewController/SVModalWebViewController.m
+++ b/SVWebViewController/SVModalWebViewController.m
@@ -18,7 +18,7 @@
 
 @implementation SVModalWebViewController
 
-@synthesize barsTintColor, availableActions, webViewController;
+@synthesize barsTintColor, availableActions, modalWebViewControllerDelegate, webViewController;
 
 #pragma mark - Initialization
 
@@ -43,6 +43,17 @@
 
 - (void)setAvailableActions:(SVWebViewControllerAvailableActions)newAvailableActions {
     self.webViewController.availableActions = newAvailableActions;
+}
+
+#pragma mark - Delegation
+
+- (void)setModalWebViewControllerDelegate:(id<SVModalWebViewControllerDelegate>)_modalWebViewControllerDelegate {
+    modalWebViewControllerDelegate = _modalWebViewControllerDelegate;
+    if ([self.modalWebViewControllerDelegate respondsToSelector:@selector(modalWebViewControllerDoneButtonTouched:)]) {
+        
+        self.webViewController.navigationItem.leftBarButtonItem.target = self.modalWebViewControllerDelegate;
+        self.webViewController.navigationItem.leftBarButtonItem.action = @selector(modalWebViewControllerDoneButtonTouched:);
+    }
 }
 
 @end


### PR DESCRIPTION
Use case:
Customize the animation to present/dismiss the modal view, so we need to be able to handle the modal show (ok), but also the **dismiss** (ko).

Added a modalWebViewControllerDelegate with method :

```
- (void)modalWebViewControllerDoneButtonTouched:(SVModalWebViewController *)modalWebViewController
```

which will be called on done button touch.
