### PR TITLE
Calls setNetworkActivityIndicatorVisible:NO on -viewDidDisappear.

### DIFF
--- a/SVWebViewController/SVWebViewController.m
+++ b/SVWebViewController/SVWebViewController.m
@@ -174,6 +174,10 @@
     }
 }
 
+- (void)viewDidDisappear:(BOOL)animated {
+    [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
+}
+
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation {
     
     if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)


### PR DESCRIPTION
This fixes an issue where the global network activity indicator would continue spinning after an SVWebViewController disappeared while loading was in process.

Currently the indicator is only hidden upon successful loading or an error, so it continues to spin if the view unloads before a request can finish or fail.
