### PR TITLE
Fix for crash when SVWebViewController deallocated before webView callbacks finish

### DIFF
--- a/SVWebViewController/SVWebViewController.m
+++ b/SVWebViewController/SVWebViewController.m
@@ -186,6 +186,13 @@
     return toInterfaceOrientation != UIInterfaceOrientationPortraitUpsideDown;
 }
 
+- (void)dealloc
+{
+    [mainWebView stopLoading];
+ 	[[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
+    mainWebView.delegate = nil;
+}
+
 #pragma mark - Toolbar
 
 - (void)updateToolbarItems {


### PR DESCRIPTION
Hi Sam,

Thanks for sharing this component with us! I came across an issue today in testing where my app would crash if I popped SVWebViewController from a UINavigationController before the internal web view finished loading. Turns out the web view delegate needed to be nilled out when SVWebViewController is deallocated, otherwise we've got some zombies on our hands. 

I think this pull request should resolve the issue.

Thanks again,

John
