### PR TITLE
Allow overriding request loading logic in subclasses

### DIFF
--- a/SVWebViewController/SVWebViewController.h
+++ b/SVWebViewController/SVWebViewController.h
@@ -14,7 +14,6 @@
 
 - (id)initWithAddress:(NSString*)urlString;
 - (id)initWithURL:(NSURL*)URL;
-- (void)loadURL:(NSURL*)URL;
 
 @property (nonatomic, readwrite) SVWebViewControllerAvailableActions availableActions;
 

--- a/SVWebViewController/SVWebViewController.m
+++ b/SVWebViewController/SVWebViewController.m
@@ -22,6 +22,7 @@
 
 - (id)initWithAddress:(NSString*)urlString;
 - (id)initWithURL:(NSURL*)URL;
+- (void)loadURL:(NSURL*)URL;
 
 - (void)updateToolbarItems;
 
@@ -133,8 +134,7 @@
     return self;
 }
 
-- (void)loadURL:(NSURL *)pageURL
-{
+- (void)loadURL:(NSURL *)pageURL {
     [mainWebView loadRequest:[NSURLRequest requestWithURL:pageURL]];
 }
 


### PR DESCRIPTION
We use SVWebViewController to access pages from our website that require authentication. In order to ensure the user is authenticated, we have to first make an API call before the page is loaded in the WebView.

We tried making the API call before loading SVWebViewController, but it adds perceived latency, so instead we decided to handle the authenticating API call at the point where the view is actually loaded.

This PR just defines `-loadURL:` which `-loadView` delegates to to do the actual loading. The default implementation remains unchanged, but it's possible to do some asynchronous work here in a subclass.
