### PR TITLE
WebView Delegation

### DIFF
--- a/SVWebViewController/SVModalWebViewController.h
+++ b/SVWebViewController/SVModalWebViewController.h
@@ -18,8 +18,13 @@ enum {
 
 typedef NSUInteger SVWebViewControllerAvailableActions;
 
-
 @class SVWebViewController;
+
+@protocol SVModalWebViewControllerDelegate <NSObject>
+-(void)webViewDidStartLoad:(UIWebView*)webView;
+-(void)webViewDidFinishLoad:(UIWebView*)webView;
+-(void)webView:(UIWebView*)webView didFailLoadWithError:(NSError *)error;
+@end
 
 @interface SVModalWebViewController : UINavigationController
 
@@ -28,5 +33,6 @@ typedef NSUInteger SVWebViewControllerAvailableActions;
 
 @property (nonatomic, strong) UIColor *barsTintColor;
 @property (nonatomic, readwrite) SVWebViewControllerAvailableActions availableActions;
+@property (nonatomic, weak) id <SVModalWebViewControllerDelegate> webViewDelegate;
 
 @end

--- a/SVWebViewController/SVModalWebViewController.m
+++ b/SVWebViewController/SVModalWebViewController.m
@@ -9,7 +9,7 @@
 #import "SVModalWebViewController.h"
 #import "SVWebViewController.h"
 
-@interface SVModalWebViewController ()
+@interface SVModalWebViewController () <SVWebViewControllerDelegate>
 
 @property (nonatomic, strong) SVWebViewController *webViewController;
 
@@ -29,6 +29,7 @@
 
 - (id)initWithURL:(NSURL *)URL {
     self.webViewController = [[SVWebViewController alloc] initWithURL:URL];
+    self.webViewController.delegate = self;
     if (self = [super initWithRootViewController:self.webViewController]) {
         self.webViewController.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:webViewController action:@selector(doneButtonClicked:)];
     }
@@ -43,6 +44,21 @@
 
 - (void)setAvailableActions:(SVWebViewControllerAvailableActions)newAvailableActions {
     self.webViewController.availableActions = newAvailableActions;
+}
+
+#pragma mark - WebView delegate
+- (void)webViewDidStartLoad:(UIWebView *)webView {
+    [self.webViewDelegate webViewDidStartLoad:webView];
+}
+
+
+- (void)webViewDidFinishLoad:(UIWebView *)webView {
+	[[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
+    [self.webViewDelegate webViewDidFinishLoad:webView];
+}
+
+- (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error {
+    [self.webViewDelegate webView:webView didFailLoadWithError:error];
 }
 
 @end

--- a/SVWebViewController/SVWebViewController.h
+++ b/SVWebViewController/SVWebViewController.h
@@ -10,11 +10,18 @@
 
 #import "SVModalWebViewController.h"
 
+@protocol SVWebViewControllerDelegate <NSObject>
+-(void)webViewDidStartLoad:(UIWebView*)webView;
+-(void)webViewDidFinishLoad:(UIWebView*)webView;
+-(void)webView:(UIWebView*)webView didFailLoadWithError:(NSError *)error;
+@end
+
 @interface SVWebViewController : UIViewController
 
 - (id)initWithAddress:(NSString*)urlString;
 - (id)initWithURL:(NSURL*)URL;
 
+@property (nonatomic, weak) id <SVWebViewControllerDelegate> delegate;
 @property (nonatomic, readwrite) SVWebViewControllerAvailableActions availableActions;
 
 @end

--- a/SVWebViewController/SVWebViewController.m
+++ b/SVWebViewController/SVWebViewController.m
@@ -287,21 +287,24 @@
 #pragma mark UIWebViewDelegate
 
 - (void)webViewDidStartLoad:(UIWebView *)webView {
-	[[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
+    [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
     [self updateToolbarItems];
+    [self.delegate webViewDidStartLoad:webView];
 }
 
 
 - (void)webViewDidFinishLoad:(UIWebView *)webView {
-	[[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
+    [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
     
     self.navigationItem.title = [webView stringByEvaluatingJavaScriptFromString:@"document.title"];
     [self updateToolbarItems];
+    [self.delegate webViewDidFinishLoad:webView];
 }
 
 - (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error {
-	[[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
+    [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
     [self updateToolbarItems];
+    [self.delegate webView:webView didFailLoadWithError:error];
 }
 
 #pragma mark - Target actions


### PR DESCRIPTION
In case a user needs to access the webview for different uses such as:

``` objective-c
NSString *html = [webView stringByEvaluatingJavaScriptFromString:
                      @"document.body.innerHTML"];
```

The commits appended add the delegation needed to expose the webview by bubbling it's own delegate methods through SVWebViewController.
