### PR TITLE
SVModalWebViewController set title first

### DIFF
--- a/SVWebViewController/SVModalWebViewController.m
+++ b/SVWebViewController/SVModalWebViewController.m
@@ -38,6 +38,7 @@
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:NO];
     
+    self.webViewController.title = self.title;
     self.navigationBar.tintColor = self.barsTintColor;
 }
 


### PR DESCRIPTION
Hi Sam,

just a simple improvement when using the modal WebViewController:
-- use the UINavigationController title for the modal view first

Best regards,
Sascha
