### PR TITLE
Added button that allows people get built application in their devices from browser

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -19,6 +19,9 @@ h2. Installation
 
 * Drag the @SVWebViewController/SVWebViewController@ folder into your project. 
 * Add the *MessageUI* framework to your project
+<div class="macbuildserver-block">
+    <a class="macbuildserver-button" href="http://macbuildserver.com/project/github/build/?xcode_project=Demo%2FSVWeb.xcodeproj&amp;target=SVWeb&amp;repo_url=https%3A%2F%2Fgithub.com%2Fsamvermette%2FSVWebViewController&amp;build_conf=Release" target="_blank"><img src="http://com.macbuildserver.github.s3-website-us-east-1.amazonaws.com/button_up.png"/></a><br/><sup><a href="http://macbuildserver.com/github/opensource/" target="_blank">by MacBuildServer</a></sup>
+</div>
 
 h2. Usage
 


### PR DESCRIPTION
Hey,

I've added 'Install app' button into your README file. Anyone could try your sample application right in browser. Look how it's working!

To learn more, please look at: http://macbuildserver.com/github/opensource/
