### PR TITLE
Adding delegate for web view callbacks

### DIFF
--- a/SVWebViewController/SVModalWebViewController.m
+++ b/SVWebViewController/SVModalWebViewController.m
@@ -47,7 +47,7 @@
 }
 
 - (void)setDelegate:(id<SVWebViewDelegate>)delegate {
-    self.webViewController.delegate = delegate;
+    self.webViewController.svDelegate = delegate;
 }
 
 @end

--- a/SVWebViewController/SVWebViewController.h
+++ b/SVWebViewController/SVWebViewController.h
@@ -13,9 +13,9 @@
 @protocol SVWebViewDelegate <NSObject>
 
 @optional
-- (void)webViewDidStartLoad:(UIWebView*)webView;
-- (void)webViewDidFinishLoad:(UIWebView*)webView;
-- (void)webView:(UIWebView*)webView didFailLoadWithError:(NSError *)error;
+- (void)svWebViewDidStartLoad:(UIWebView*)webView;
+- (void)svWebViewDidFinishLoad:(UIWebView*)webView;
+- (void)svWebView:(UIWebView*)webView didFailLoadWithError:(NSError *)error;
 
 @end
 
@@ -26,6 +26,6 @@
 - (id)initWithURL:(NSURL*)URL;
 
 @property (nonatomic, readwrite) SVWebViewControllerAvailableActions availableActions;
-@property (nonatomic, strong) id<SVWebViewDelegate> delegate;
+@property (nonatomic, strong) id<SVWebViewDelegate> svDelegate;
 
 @end

--- a/SVWebViewController/SVWebViewController.m
+++ b/SVWebViewController/SVWebViewController.m
@@ -291,8 +291,8 @@
 	[[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
     [self updateToolbarItems];
     
-    if ([self.delegate respondsToSelector:@selector(webViewDidStartLoad:)]) {
-        [self.delegate webViewDidStartLoad:webView];
+    if ([self.svDelegate respondsToSelector:@selector(svWebViewDidStartLoad:)]) {
+        [self.svDelegate svWebViewDidStartLoad:webView];
     }
 }
 
@@ -303,8 +303,8 @@
     self.navigationItem.title = [webView stringByEvaluatingJavaScriptFromString:@"document.title"];
     [self updateToolbarItems];
     
-    if ([self.delegate respondsToSelector:@selector(webViewDidFinishLoad:)]) {
-        [self.delegate webViewDidFinishLoad:webView];
+    if ([self.svDelegate respondsToSelector:@selector(svWebViewDidFinishLoad:)]) {
+        [self.svDelegate svWebViewDidFinishLoad:webView];
     }
 }
 
@@ -312,8 +312,8 @@
 	[[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
     [self updateToolbarItems];
     
-    if ([self.delegate respondsToSelector:@selector(webView:didFailLoadWithError:)]) {
-        [self.delegate webView:webView didFailLoadWithError:error];
+    if ([self.svDelegate respondsToSelector:@selector(svWebView:didFailLoadWithError:)]) {
+        [self.svDelegate svWebView:webView didFailLoadWithError:error];
     }
 }
 


### PR DESCRIPTION
I know there's already another pull request for adding a webview delegate, though this one is a little nicer.

The callbacks are now all optional, and I've also changed the delegate names so they don't conflict with the real webview callbacks (and thereby don't override them like the other pull request).

Oh, and I've also created a nice accessor to set the delegate on the modal webview, which will set the delegate on the base webview.
