### PR TITLE
Supress Xcode undeclared selector warning

### DIFF
--- a/SVWebViewController/SVWebViewController.h
+++ b/SVWebViewController/SVWebViewController.h
@@ -13,4 +13,6 @@
 - (id)initWithAddress:(NSString*)urlString;
 - (id)initWithURL:(NSURL*)URL;
 
+- (void)doneButtonClicked:(id)sender;
+
 @end


### PR DESCRIPTION
Supressed Xcode undeclared selector warning in SVModalWebViewController.m on line 
`UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self.webViewController action:@selector(doneButtonClicked:)];`
