### PR TITLE
Added ability to customize how networkActivityIndicator is managed

### DIFF
--- a/SVWebViewController/SVModalWebViewController.h
+++ b/SVWebViewController/SVModalWebViewController.h
@@ -10,7 +10,11 @@
 
 @class SVWebViewController;
 
-@interface SVModalWebViewController : UINavigationController
+@interface SVModalWebViewController : UINavigationController {
+    void(^_customSetNetworkActivityIndicatorVisible)(BOOL networkActivityIndicatorVisible);
+}
+
+@property (nonatomic, copy) void(^customSetNetworkActivityIndicatorVisible)(BOOL networkActivityIndicatorVisible);
 
 - (id)initWithAddress:(NSString*)urlString;
 - (id)initWithURL:(NSURL *)URL;

--- a/SVWebViewController/SVModalWebViewController.m
+++ b/SVWebViewController/SVModalWebViewController.m
@@ -18,6 +18,8 @@
 
 @implementation SVModalWebViewController
 
+@synthesize customSetNetworkActivityIndicatorVisible = _customSetNetworkActivityIndicatorVisible;
+
 #pragma mark - Initialization
 
 
@@ -45,6 +47,14 @@
     
     self.webViewController.title = self.title;
     self.navigationBar.tintColor = self.barsTintColor;
+}
+
+#pragma mark - Accessors
+-(void) setCustomSetNetworkActivityIndicatorVisible:(void (^)(BOOL))customSetNetworkActivityIndicatorVisible
+{
+    _customSetNetworkActivityIndicatorVisible = customSetNetworkActivityIndicatorVisible;
+    
+    self.webViewController.customSetNetworkActivityIndicatorVisible = customSetNetworkActivityIndicatorVisible;
 }
 
 @end

--- a/SVWebViewController/SVWebViewController.h
+++ b/SVWebViewController/SVWebViewController.h
@@ -8,7 +8,11 @@
 
 #import "SVModalWebViewController.h"
 
-@interface SVWebViewController : UIViewController
+@interface SVWebViewController : UIViewController {
+    void(^_customSetNetworkActivityIndicatorVisible)(BOOL networkActivityIndicatorVisible);
+}
+
+@property (copy) void(^customSetNetworkActivityIndicatorVisible)(BOOL networkActivityIndicatorVisible);
 
 - (id)initWithAddress:(NSString*)urlString;
 - (id)initWithURL:(NSURL*)URL;

--- a/SVWebViewController/SVWebViewController.m
+++ b/SVWebViewController/SVWebViewController.m
@@ -38,11 +38,13 @@
 
 @implementation SVWebViewController
 
+@synthesize customSetNetworkActivityIndicatorVisible = _customSetNetworkActivityIndicatorVisible;
+
 #pragma mark - Initialization
 
 - (void)dealloc {
     [self.webView stopLoading];
- 	[[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
+    [self setNetworkActivityIndicatorVisible:NO];
     self.webView.delegate = nil;
 }
 
@@ -61,6 +63,16 @@
 
 - (void)loadURL:(NSURL *)pageURL {
     [self.webView loadRequest:[NSURLRequest requestWithURL:pageURL]];
+}
+
+- (void)setNetworkActivityIndicatorVisible:(BOOL) networkActivityIndicatorVisible
+{
+    if (self.customSetNetworkActivityIndicatorVisible != nil) {
+        self.customSetNetworkActivityIndicatorVisible(networkActivityIndicatorVisible);
+        return;
+    }
+    
+    [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:networkActivityIndicatorVisible];
 }
 
 #pragma mark - View lifecycle
@@ -105,7 +117,7 @@
 
 - (void)viewDidDisappear:(BOOL)animated {
     [super viewDidDisappear:animated];
-    [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
+    [self setNetworkActivityIndicatorVisible:NO];
 }
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation {
@@ -225,20 +237,20 @@
 #pragma mark - UIWebViewDelegate
 
 - (void)webViewDidStartLoad:(UIWebView *)webView {
-	[[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
+    [self setNetworkActivityIndicatorVisible:YES];
     [self updateToolbarItems];
 }
 
 
 - (void)webViewDidFinishLoad:(UIWebView *)webView {
-	[[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
+    [self setNetworkActivityIndicatorVisible:NO];
     
     self.navigationItem.title = [webView stringByEvaluatingJavaScriptFromString:@"document.title"];
     [self updateToolbarItems];
 }
 
 - (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error {
-	[[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
+    [self setNetworkActivityIndicatorVisible:NO];
     [self updateToolbarItems];
 }
 


### PR DESCRIPTION
In some cases, it might be useful to customize how the networkActivityIndicator visibility is turned off or on. For example, we might have a central manager to do this, in case there are other threads that are also accessing the network. In my app, I use AFNetworking which manages a count of networkActivityIndicator setVisible requests and turns it on and off appropriately. Directly setting the activity indicator visibility to on/off via UIApplication in this case will not be truly representative of the actual network activity. So, I set up a block property where this custom behavior can be defined

```
modalWebViewController.customSetNetworkActivityIndicatorVisible = ^(BOOL networkActivityIndicatorVisible) {
        if (networkActivityIndicatorVisible)
            [[AFNetworkActivityIndicatorManager sharedManager] incrementActivityCount];
        else
            [[AFNetworkActivityIndicatorManager sharedManager] decrementActivityCount];
    };
```

Hope others will find this useful as well :)
