### PR TITLE
Adding in logic to test to see if a navigation item title is set before ...

### DIFF
--- a/SVWebViewController/SVWebViewController.m
+++ b/SVWebViewController/SVWebViewController.m
@@ -233,7 +233,10 @@
 - (void)webViewDidFinishLoad:(UIWebView *)webView {
 	[[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
     
-    self.navigationItem.title = [webView stringByEvaluatingJavaScriptFromString:@"document.title"];
+    if([self.navigationItem.title isEqualToString:@""] || self.navigationItem.title == nil || self.navigationItem.title.length == 0){
+        self.navigationItem.title = [webView stringByEvaluatingJavaScriptFromString:@"document.title"];
+    }
+    
     [self updateToolbarItems];
 }
 


### PR DESCRIPTION
It seems like it should be allowed to hard set the title attribute if an individual doesn't want to use the title that is on the html file or is loading a PDF file. 
