### PR TITLE
Make webView property accessible to children

### DIFF
--- a/SVWebViewController/SVWebViewController.h
+++ b/SVWebViewController/SVWebViewController.h
@@ -13,5 +13,6 @@
 - (instancetype)initWithURLRequest:(NSURLRequest *)request;
 
 @property (nonatomic, weak) id<UIWebViewDelegate> delegate;
+@property (nonatomic, strong) UIWebView *webView;
 
 @end

--- a/SVWebViewController/SVWebViewController.m
+++ b/SVWebViewController/SVWebViewController.m
@@ -18,7 +18,6 @@
 @property (nonatomic, strong) UIBarButtonItem *stopBarButtonItem;
 @property (nonatomic, strong) UIBarButtonItem *actionBarButtonItem;
 
-@property (nonatomic, strong) UIWebView *webView;
 @property (nonatomic, strong) NSURLRequest *request;
 
 @end


### PR DESCRIPTION
I moved the webView variable into the header so that descendant classes can access the webView. This allows for alternate data loading such as loading data directly with the webView.loadData method.
